### PR TITLE
Adapt hono app for deno deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,51 @@ Cheers 🎉
 
 ## Deployment 🚀
 
+### Deno Deploy
+
+This project can be deployed on [Deno Deploy](https://deno.com/deploy) for better reliability and performance.
+
+#### Setup Steps
+
+1. **Fork or clone this repository**
+
+2. **Connect to Deno Deploy:**
+   - Go to [dash.deno.com](https://dash.deno.com)
+   - Create a new project
+   - Connect your GitHub repository
+   - Set the entrypoint to `main.ts`
+   - Choose "None (Custom)" as the framework preset
+
+3. **Environment Variables (if needed):**
+   - Add any required environment variables in the Deno Deploy dashboard
+   - Access them in your code using `Deno.env.get("VARIABLE_NAME")`
+
+4. **Deploy:**
+   - Push your changes to the connected branch
+   - Deno Deploy will automatically build and deploy your application
+
+#### Local Development
+
+```bash
+# Install Deno (if not already installed)
+curl -fsSL https://deno.land/install.sh | sh
+
+# Run the development server
+deno task dev
+
+# Or run directly
+deno run --allow-net --allow-env main.ts
+```
+
+#### Advantages over Cloudflare Workers
+- No ASN blocking issues with Amazon
+- Better TypeScript support
+- Native URL imports
+- More stable IP ranges
+- Simpler deployment process
+
+### Cloudflare Workers (Legacy)
+
 [![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/tuhinpal/amazon-api)
 
 ## Implented country versions 🌍

--- a/deno.json
+++ b/deno.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "lib": ["deno.ns", "deno.window"],
+    "jsx": "react-jsx",
+    "jsxImportSource": "https://deno.land/x/hono@v4.3.1/jsx"
+  },
+  "imports": {
+    "@/": "./src/",
+    "hono": "https://deno.land/x/hono@v4.3.1/mod.ts",
+    "hono/": "https://deno.land/x/hono@v4.3.1/",
+    "@hono/graphql-server": "https://deno.land/x/hono_graphql@v0.4.3/mod.ts",
+    "graphql": "https://deno.land/x/graphql_deno@v15.0.0/mod.ts",
+    "linkedom": "https://esm.sh/linkedom@0.16.11",
+    "any-date-parser": "https://esm.sh/any-date-parser@1.5.4"
+  },
+  "tasks": {
+    "dev": "deno run --allow-net --allow-env --watch main.ts",
+    "start": "deno run --allow-net --allow-env main.ts"
+  }
+}

--- a/main.ts
+++ b/main.ts
@@ -1,0 +1,5 @@
+// main.ts - Deno Deploy entrypoint
+import app from "./src/index.ts";
+
+// Deno Deploy automatically binds to the right port
+Deno.serve(app.fetch);

--- a/src/common/amazon-api/index.ts
+++ b/src/common/amazon-api/index.ts
@@ -1,4 +1,4 @@
-import { HTTPException } from "hono/http-exception";
+import { HTTPException } from "hono";
 
 export interface AmazonApiProps {
   amazonBase: string;

--- a/src/common/middlewares/country.middlewware.ts
+++ b/src/common/middlewares/country.middlewware.ts
@@ -1,5 +1,4 @@
-import { Context, Next } from "hono";
-import { createMiddleware } from "hono/factory";
+import { Context, Next, createMiddleware } from "hono";
 import { parseCountry } from "../utils/country";
 
 export const countryMiddleware = createMiddleware(

--- a/src/common/utils/country.ts
+++ b/src/common/utils/country.ts
@@ -1,5 +1,5 @@
 import { COUNTRYWISE_AMAZON_API_BASE } from "@/config";
-import { HTTPException } from "hono/http-exception";
+import { HTTPException } from "hono";
 
 export const parseCountry = (country: string) => {
   const countryBase =

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,6 @@
-import { Hono } from "hono";
+import { Hono, HTTPException } from "hono";
 import routes from "@/routes";
 import graphql from "@/graphql";
-import { HTTPException } from "hono/http-exception";
 
 const app = new Hono();
 

--- a/src/product/product.service.ts
+++ b/src/product/product.service.ts
@@ -1,6 +1,6 @@
 import { amazonApi } from "@/common/amazon-api";
 import { parseHTML } from "linkedom";
-import { HTTPException } from "hono/http-exception";
+import { HTTPException } from "hono";
 import { getCurrencyFromSymbol } from "@/common/utils/currency";
 import { parseNumber } from "@/common/utils/number";
 import { createImageVariants } from "@/common/utils/image";

--- a/src/search/search.controller.ts
+++ b/src/search/search.controller.ts
@@ -1,6 +1,5 @@
-import { Context } from "hono";
+import { Context, HTTPException } from "hono";
 import * as searchService from "@/search/search.service";
-import { HTTPException } from "hono/http-exception";
 import { parseCountry } from "@/common/utils/country";
 
 export const search = async (c: Context) => {

--- a/src/search/search.service.ts
+++ b/src/search/search.service.ts
@@ -5,7 +5,7 @@ import { getCurrencyFromSymbol } from "@/common/utils/currency";
 import { createImageVariants } from "@/common/utils/image";
 import { parseNumber } from "@/common/utils/number";
 import { SearchItem, SearchResult } from "@/types/Search";
-import { HTTPException } from "hono/http-exception";
+import { HTTPException } from "hono";
 import { parseHTML } from "linkedom";
 
 export const search = async ({

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,10 @@
 {
   "compilerOptions": {
     "target": "ESNext",
-    "module": "ESNext",
-    "moduleResolution": "Bundler",
+    "module": "ESNext", 
+    "moduleResolution": "Node",
     "strict": true,
     "lib": ["ESNext", "DOM"],
-    "types": ["@cloudflare/workers-types"],
     "jsx": "react-jsx",
     "jsxImportSource": "hono/jsx",
     "paths": {


### PR DESCRIPTION
Migrate the Hono application from Cloudflare Workers to Deno Deploy for improved reliability and native Deno runtime benefits.

---
<a href="https://cursor.com/background-agent?bcId=bc-e61426ab-71e5-4f52-9a84-115fa3208f57">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e61426ab-71e5-4f52-9a84-115fa3208f57">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

