### PR TITLE
Fix missing file extensions in imports

### DIFF
--- a/src/common/utils/country.ts
+++ b/src/common/utils/country.ts
@@ -1,4 +1,4 @@
-import { COUNTRYWISE_AMAZON_API_BASE } from "@/config";
+import { COUNTRYWISE_AMAZON_API_BASE } from "@/config.ts";
 import { HTTPException } from "hono";
 
 export const parseCountry = (country: string) => {

--- a/src/common/utils/image.ts
+++ b/src/common/utils/image.ts
@@ -1,4 +1,4 @@
-import { Image } from "@/types/Common";
+import { Image } from "@/types/Common.ts";
 
 export function createImageVariants(
   imageUrl: string | null | undefined

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -2,13 +2,13 @@ import { Hono } from "hono";
 import { graphqlServer } from "@hono/graphql-server";
 import { buildSchema } from "graphql";
 
-import { SearchSchema } from "@/types/Search";
-import { CommonSchema } from "@/types/Common";
-import { ProductSchema } from "@/types/Product";
-import * as searchController from "@/search/search.controller";
-import * as productController from "@/product/product.controller";
+import { SearchSchema } from "@/types/Search.ts";
+import { CommonSchema } from "@/types/Common.ts";
+import { ProductSchema } from "@/types/Product.ts";
+import * as searchController from "@/search/search.controller.ts";
+import * as productController from "@/product/product.controller.ts";
 
-import playgroundHandler from "@/common/playground";
+import playgroundHandler from "@/common/playground/index.ts";
 
 const graphql = new Hono();
 

--- a/src/product/product.controller.ts
+++ b/src/product/product.controller.ts
@@ -1,6 +1,6 @@
 import { Context } from "hono";
-import * as productService from "@/product/product.service";
-import { parseCountry } from "@/common/utils/country";
+import * as productService from "@/product/product.service.ts";
+import { parseCountry } from "@/common/utils/country.ts";
 
 export const get = async (c: Context) => {
   const id = c.req.param("id");

--- a/src/product/product.routes.ts
+++ b/src/product/product.routes.ts
@@ -1,5 +1,5 @@
 import { Hono } from "hono";
-import * as productController from "@/product/product.controller";
+import * as productController from "@/product/product.controller.ts";
 
 const product = new Hono();
 

--- a/src/product/product.service.ts
+++ b/src/product/product.service.ts
@@ -1,11 +1,11 @@
-import { amazonApi } from "@/common/amazon-api";
+import { amazonApi } from "@/common/amazon-api/index.ts";
 import { parseHTML } from "linkedom";
 import { HTTPException } from "hono";
-import { getCurrencyFromSymbol } from "@/common/utils/currency";
-import { parseNumber } from "@/common/utils/number";
-import { createImageVariants } from "@/common/utils/image";
-import { parseTable } from "@/common/utils/table";
-import { InsightAspect, Product, RatingReview } from "@/types/Product";
+import { getCurrencyFromSymbol } from "@/common/utils/currency.ts";
+import { parseNumber } from "@/common/utils/number.ts";
+import { createImageVariants } from "@/common/utils/image.ts";
+import { parseTable } from "@/common/utils/table.ts";
+import { InsightAspect, Product, RatingReview } from "@/types/Product.ts";
 import parser from "any-date-parser";
 
 export const get = async ({

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -1,7 +1,7 @@
 import { Hono } from "hono";
 import searchRoutes from "./search/search.routes.ts";
 import productRoutes from "./product/product.routes.ts";
-import { countryMiddleware } from "./common/middlewares/country.middlewware";
+import { countryMiddleware } from "./common/middlewares/country.middlewware.ts";
 
 const routes = new Hono();
 

--- a/src/search/search.controller.ts
+++ b/src/search/search.controller.ts
@@ -1,6 +1,6 @@
 import { Context, HTTPException } from "hono";
-import * as searchService from "@/search/search.service";
-import { parseCountry } from "@/common/utils/country";
+import * as searchService from "@/search/search.service.ts";
+import { parseCountry } from "@/common/utils/country.ts";
 
 export const search = async (c: Context) => {
   const query = c.req.query("query");

--- a/src/search/search.routes.ts
+++ b/src/search/search.routes.ts
@@ -1,5 +1,5 @@
 import { Hono } from "hono";
-import * as searchController from "@/search/search.controller";
+import * as searchController from "@/search/search.controller.ts";
 
 const search = new Hono();
 

--- a/src/search/search.service.ts
+++ b/src/search/search.service.ts
@@ -1,10 +1,10 @@
-import { amazonApi } from "@/common/amazon-api";
-import logger from "@/common/logger";
-import { buildApiUrl } from "@/common/utils/api-url";
-import { getCurrencyFromSymbol } from "@/common/utils/currency";
-import { createImageVariants } from "@/common/utils/image";
-import { parseNumber } from "@/common/utils/number";
-import { SearchItem, SearchResult } from "@/types/Search";
+import { amazonApi } from "@/common/amazon-api/index.ts";
+import logger from "@/common/logger/index.ts";
+import { buildApiUrl } from "@/common/utils/api-url.ts";
+import { getCurrencyFromSymbol } from "@/common/utils/currency.ts";
+import { createImageVariants } from "@/common/utils/image.ts";
+import { parseNumber } from "@/common/utils/number.ts";
+import { SearchItem, SearchResult } from "@/types/Search.ts";
 import { HTTPException } from "hono";
 import { parseHTML } from "linkedom";
 

--- a/src/types/Product.ts
+++ b/src/types/Product.ts
@@ -1,4 +1,4 @@
-import { Image } from "./Common";
+import { Image } from "./Common.ts";
 
 export interface InsightAspect {
   aspect: string;

--- a/src/types/Search.ts
+++ b/src/types/Search.ts
@@ -1,4 +1,4 @@
-import { Image } from "./Common";
+import { Image } from "./Common.ts";
 
 export interface SearchItem {
   id: string;


### PR DESCRIPTION
Add `.ts` extensions to all module imports to resolve Deno's "Module not found" errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-c6cf8009-206c-4fea-a8cf-b590ce112315">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c6cf8009-206c-4fea-a8cf-b590ce112315">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

